### PR TITLE
CI against rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ notifications:
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - gemfile: gemfiles/activerecord_5_1.gemfile
   exclude:
   # NOTE: activesupport 5.x requires Ruby version >= 2.2.2
   - rvm: 2.1

--- a/gemfiles/activerecord_5_1.gemfile
+++ b/gemfiles/activerecord_5_1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1.0.beta1"
+gem "activerecord", "~> 5.1.0"
 
 gemspec path: '../'
 


### PR DESCRIPTION
Rails 5.1.0 is released! 🎉 
http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/