### PR TITLE
Fixed CI for pg v1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in index_shotgun.gemspec
 gemspec
 
+group :postgresql do
+  gem "pg"
+end
+
 eval(Pathname("gemfiles/common.gemfile").read) # rubocop:disable Security/Eval

--- a/gemfiles/activerecord_4_2.gemfile
+++ b/gemfiles/activerecord_4_2.gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0"
 
+group :postgresql do
+  # https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L16
+  gem "pg", "~> 0.15"
+end
+
 gemspec path: '../'
 
 eval(Pathname("#{__dir__}/common.gemfile").read)

--- a/gemfiles/activerecord_5_0.gemfile
+++ b/gemfiles/activerecord_5_0.gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 
+group :postgresql do
+  # https://github.com/rails/rails/blob/v5.0.6/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L2
+  gem "pg", "~> 0.18"
+end
+
 gemspec path: '../'
 
 eval(Pathname("#{__dir__}/common.gemfile").read)

--- a/gemfiles/activerecord_5_1.gemfile
+++ b/gemfiles/activerecord_5_1.gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.1.0"
 
+group :postgresql do
+  # https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L2
+  gem "pg", "~> 0.18"
+end
+
 gemspec path: '../'
 
 eval(Pathname("#{__dir__}/common.gemfile").read)

--- a/gemfiles/activerecord_5_2.gemfile
+++ b/gemfiles/activerecord_5_2.gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.0.beta2"
 
+group :postgresql do
+  # https://github.com/rails/rails/blob/v5.2.0.beta2/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L4
+  gem "pg", "~> 0.18"
+end
+
 gemspec path: '../'
 
 eval(Pathname("#{__dir__}/common.gemfile").read)

--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -7,10 +7,6 @@ group :oracle do
   gem "ruby-oci8"
 end
 
-group :postgresql do
-  gem "pg"
-end
-
 group :sqlite3 do
   gem "sqlite3"
 end


### PR DESCRIPTION
c.f. https://travis-ci.org/sue445/index_shotgun/jobs/328719132

```
+bundle exec rspec
bundler: failed to load command: rspec (/home/travis/build/sue445/index_shotgun/gemfiles/vendor/bundle/ruby/2.6.0/bin/rspec)
Gem::LoadError: Error loading the 'postgresql' Active Record adapter. Missing a gem it depends on? can't activate pg (~> 0.18), already activated pg-1.0.0. Make sure all dependencies are added to Gemfile.
```

`pg` v1.0.0 was released. 
https://rubygems.org/gems/pg/versions/1.0.0

But `activerecord` (<= v5.2.0.beta2) doesn't support this yet.