### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,4 @@ matrix:
       gemfile: gemfiles/activerecord_6_0.gemfile
 cache: bundler
 sudo: false
+dist: trusty


### PR DESCRIPTION
# Before (success)
https://travis-ci.org/sue445/index_shotgun/builds/558280299

```
mysql version
mysql  Ver 14.14 Distrib 5.6.33, for debian-linux-gnu (x86_64) using  EditLine wrapper
postgresql client version
psql (PostgreSQL) 9.6.6
```

# After (failed)
https://travis-ci.org/sue445/index_shotgun/builds/561435534

```
mysql version
mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper
postgresql client version
psql (PostgreSQL) 10.7 (Ubuntu 10.7-1.pgdg16.04+1)
```