### PR TITLE
Drop support ruby 2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.3"
           - "2.4"
           - "2.5"
           - "2.6"
@@ -38,12 +37,8 @@ jobs:
           - activerecord_6_1
         exclude:
           # Rails 6.0+ requires Ruby 2.5+
-          - ruby:    "2.3"
-            gemfile: activerecord_6_0
           - ruby:    "2.4"
             gemfile: activerecord_6_0
-          - ruby:    "2.3"
-            gemfile: activerecord_6_1
           - ruby:    "2.4"
             gemfile: activerecord_6_1
 
@@ -120,7 +115,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.3"
           - "2.4"
           - "2.5"
           - "2.6"
@@ -133,10 +127,6 @@ jobs:
           - activerecord_6_0
           - activerecord_6_1
         include:
-          # FIXME: SEGV on Ruby 2.3 + MySQL
-          # https://github.com/sue445/index_shotgun/runs/433443396?check_suite_focus=true
-          - ruby:   "2.3"
-            runner: ubuntu-16.04
           - ruby:   "2.4"
             runner: ubuntu-latest
           - ruby:   "2.5"
@@ -149,12 +139,8 @@ jobs:
             runner: ubuntu-latest
         exclude:
           # Rails 6.0+ requires Ruby 2.5+
-          - ruby:    "2.3"
-            gemfile: activerecord_6_0
           - ruby:    "2.4"
             gemfile: activerecord_6_0
-          - ruby:    "2.3"
-            gemfile: activerecord_6_1
           - ruby:    "2.4"
             gemfile: activerecord_6_1
 
@@ -244,7 +230,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.3"
           - "2.4"
           - "2.5"
           - "2.6"
@@ -258,12 +243,8 @@ jobs:
           - activerecord_6_1
         exclude:
           # Rails 6.0+ requires Ruby 2.5+
-          - ruby:    "2.3"
-            gemfile: activerecord_6_0
           - ruby:    "2.4"
             gemfile: activerecord_6_0
-          - ruby:    "2.3"
-            gemfile: activerecord_6_1
           - ruby:    "2.4"
             gemfile: activerecord_6_1
 
@@ -352,7 +333,6 @@ jobs:
 
       matrix:
         ruby:
-          - "2.3"
           - "2.4"
           - "2.5"
           - "2.6"
@@ -366,12 +346,8 @@ jobs:
           - activerecord_6_1
         exclude:
           # Rails 6.0+ requires Ruby 2.5+
-          - ruby:    "2.3"
-            gemfile: activerecord_6_0
           - ruby:    "2.4"
             gemfile: activerecord_6_0
-          - ruby:    "2.3"
-            gemfile: activerecord_6_1
           - ruby:    "2.4"
             gemfile: activerecord_6_1
 
@@ -457,7 +433,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      RUBY_VERSION: 2.3
+      RUBY_VERSION: 2.4
 
     steps:
       - uses: actions/checkout@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
     - "config/rspec.yml"
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Layout/AlignHash:
   EnforcedHashRocketStyle: table

--- a/index_shotgun.gemspec
+++ b/index_shotgun.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/index_shotgun"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
I need [ubuntu-16.04 to build with Ruby 2.3](https://github.com/sue445/index_shotgun/blob/71547da9dd24f26ea1fcd92f9ba2bc79c55e0eaa/.github/workflows/test.yml#L136-L139), but it's already retired.

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

