### PR TITLE
Fix bundler deprecation warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_WITHOUT: mysql oracle postgresql
       DATABASE: sqlite3
 
     steps:
@@ -154,6 +155,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_WITHOUT: oracle postgresql sqlite3
       DATABASE: mysql
 
     services:
@@ -258,6 +260,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_WITHOUT: mysql oracle sqlite3
       DATABASE: postgresql
 
     services:
@@ -361,6 +364,7 @@ jobs:
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_WITHOUT: mysql postgresql sqlite3
       DATABASE: oracle
       LD_LIBRARY_PATH: /opt/oracle/instantclient_19_3
       NLS_LANG: AMERICAN_AMERICA.UTF8
@@ -434,6 +438,7 @@ jobs:
 
     env:
       RUBY_VERSION: 2.4
+      BUNDLE_WITHOUT: mysql postgresql sqlite3 oracle
 
     steps:
       - uses: actions/checkout@v1

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,19 +6,13 @@ if [ "${DATABASE}" = "mysql" ]; then
   sudo apt-get update
   sudo apt-get install -y libmysqlclient-dev
 
-  bundle install --path vendor/bundle/ --jobs 4 --retry 3 --without oracle postgresql sqlite3
-
 elif [ "${DATABASE}" = "postgresql" ]; then
   sudo apt-get update
   sudo apt-get install -y libpq-dev
 
-  bundle install --path vendor/bundle/ --jobs 4 --retry 3 --without mysql oracle sqlite3
-
 elif [ "${DATABASE}" = "sqlite3" ]; then
   sudo apt-get update
   sudo apt-get install -y libsqlite3-dev
-
-  bundle install --path vendor/bundle/ --jobs 4 --retry 3 --without mysql oracle postgresql
 
 elif [ "${DATABASE}" = "oracle" ]; then
   # c.f. https://github.com/kubo/ruby-oci8/blob/ruby-oci8-2.2.7/docs/install-instant-client.md#install-oracle-instant-client-packages
@@ -36,9 +30,10 @@ elif [ "${DATABASE}" = "oracle" ]; then
 
   popd
 
-  bundle install --path vendor/bundle/ --jobs 4 --retry 3 --without mysql postgresql sqlite3
-
 else
-  bundle install --path vendor/bundle/ --jobs 4 --retry 3 --without mysql postgresql sqlite3 oracle
+  export BUNDLE_WITHOUT="mysql postgresql sqlite3 oracle"
 
 fi
+
+bundle config set --local path "vendor/bundle/"
+bundle install --jobs $(nproc) --retry 3


### PR DESCRIPTION
https://github.com/sue445/index_shotgun/runs/3979940847?check_suite_focus=true

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle/'`, and stop using this flag
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local without 'oracle postgresql sqlite3'`, and stop using this flag
```