### PR TITLE
Fixed false positives when there are multiple unique indexes on a single table

### DIFF
--- a/lib/index_shotgun/analyzer.rb
+++ b/lib/index_shotgun/analyzer.rb
@@ -78,6 +78,8 @@ module IndexShotgun
         indexes.permutation(2).each_with_object([]) do |(source_index, target_index), response|
           next unless source_index.columns.start_with?(target_index.columns)
 
+          next if source_index.unique && target_index.unique
+
           if target_index.unique
             response << {
               index:  source_index,

--- a/spec/db/migrations.rb
+++ b/spec/db/migrations.rb
@@ -33,4 +33,16 @@ ActiveRecord::Schema.define(version: 1) do
   end
   add_index :user_stocks, [:user_id, :article_id], unique: true, name: "user_id_article_id"
   add_index :user_stocks, [:user_id, :article_id, :already_read], name: "user_id_article_id_already"
+
+  create_table :unique_user_stocks do |t|
+    t.references :user,    index: false
+    t.references :article, index: false
+    t.boolean    :already_read
+    t.text       :message
+
+    t.timestamps null: false
+  end
+  add_index :unique_user_stocks, [:user_id], unique: true, name: "index_unique_user_stocks_on_user_id"
+  add_index :unique_user_stocks, [:user_id, :article_id], unique: true, name: "index_unique_user_stocks_on_user_id_article_id"
+  add_index :unique_user_stocks, [:user_id, :article_id, :already_read], name: "index_unique_user_stocks_on_user_id_article_id_already"
 end

--- a/spec/db/migrations.rb
+++ b/spec/db/migrations.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 1) do
 
     t.timestamps null: false
   end
-  add_index :unique_user_stocks, [:user_id], unique: true, name: "index_unique_user_stocks_on_user_id"
-  add_index :unique_user_stocks, [:user_id, :article_id], unique: true, name: "index_unique_user_stocks_on_user_id_article_id"
-  add_index :unique_user_stocks, [:user_id, :article_id, :already_read], name: "index_unique_user_stocks_on_user_id_article_id_already"
+  add_index :unique_user_stocks, [:user_id], unique: true, name: "u_user_id"
+  add_index :unique_user_stocks, [:user_id, :article_id], unique: true, name: "u_user_id_article_id"
+  add_index :unique_user_stocks, [:user_id, :article_id, :already_read], name: "u_user_id_article_id_already"
 end

--- a/spec/index_shotgun/analyzer_spec.rb
+++ b/spec/index_shotgun/analyzer_spec.rb
@@ -57,6 +57,17 @@ describe IndexShotgun::Analyzer do
       it { should include "user_id_article_id_already has column(s) on the right side of unique index (user_id_article_id). You can drop if low cardinality" }
     end
 
+    context "When exists duplicate indexes (unique index on 1 and 2 columns)" do
+      let(:table) { "unique_user_stocks" }
+
+      its(:count) { should eq 2 }
+
+      # rubocop:disable Metrics/LineLength
+      it { should include "index_unique_user_stocks_on_user_id_article_id_already has column(s) on the right side of unique index (index_unique_user_stocks_on_user_id_article_id). You can drop if low cardinality" }
+      it { should include "index_unique_user_stocks_on_user_id_article_id_already has column(s) on the right side of unique index (index_unique_user_stocks_on_user_id). You can drop if low cardinality" }
+      # rubocop:enable Metrics/LineLength
+    end
+
     context "When not exists duplicate indexes" do
       let(:table) { "comments" }
 
@@ -67,11 +78,11 @@ describe IndexShotgun::Analyzer do
   describe "#perform" do
     subject { IndexShotgun::Analyzer.perform }
 
-    its(:message) { should include "# Total Duplicate Indexes  3" }
-    its(:message) { should include "# Total Indexes            5" }
-    its(:message) { should include "# Total Tables             4" }
-    its(:duplicate_index_count) { should eq 3 }
-    its(:total_index_count)     { should eq 5 }
-    its(:total_table_count)     { should eq 4 }
+    its(:message) { should include "# Total Duplicate Indexes  5" }
+    its(:message) { should include "# Total Indexes            8" }
+    its(:message) { should include "# Total Tables             5" }
+    its(:duplicate_index_count) { should eq 5 }
+    its(:total_index_count)     { should eq 8 }
+    its(:total_table_count)     { should eq 5 }
   end
 end

--- a/spec/index_shotgun/analyzer_spec.rb
+++ b/spec/index_shotgun/analyzer_spec.rb
@@ -63,8 +63,8 @@ describe IndexShotgun::Analyzer do
       its(:count) { should eq 2 }
 
       # rubocop:disable Metrics/LineLength
-      it { should include "index_unique_user_stocks_on_user_id_article_id_already has column(s) on the right side of unique index (index_unique_user_stocks_on_user_id_article_id). You can drop if low cardinality" }
-      it { should include "index_unique_user_stocks_on_user_id_article_id_already has column(s) on the right side of unique index (index_unique_user_stocks_on_user_id). You can drop if low cardinality" }
+      it { should include "u_user_id_article_id_already has column(s) on the right side of unique index (u_user_id_article_id). You can drop if low cardinality" }
+      it { should include "u_user_id_article_id_already has column(s) on the right side of unique index (u_user_id). You can drop if low cardinality" }
       # rubocop:enable Metrics/LineLength
     end
 


### PR DESCRIPTION
example table

```ruby
  create_table :unique_user_stocks do |t|
    t.references :user,    index: false
    t.references :article, index: false
    t.boolean    :already_read
    t.text       :message

    t.timestamps null: false
  end
  add_index :unique_user_stocks, [:user_id], unique: true, name: "index_unique_user_stocks_on_user_id"
  add_index :unique_user_stocks, [:user_id, :article_id], unique: true, name: "index_unique_user_stocks_on_user_id_article_id"
  add_index :unique_user_stocks, [:user_id, :article_id, :already_read], name: "index_unique_user_stocks_on_user_id_article_id_already"
```

Running index_shotgun on this table returns the following results

```
# =============================
# unique_user_stocks
# =============================

# index_unique_user_stocks_on_user_id_article_id has column(s) on the right side of unique index (index_unique_user_stocks_on_user_id). You can drop if low cardinality
# To remove this duplicate index, execute:
ALTER TABLE `unique_user_stocks` DROP INDEX `index_unique_user_stocks_on_user_id_article_id`;
```

This is due to the existence of multiple unique indexes for `(used_id)` and `(used_id, article_id)`.

In such a case, each of all unique indexes are considered meaningful and should not be dropped.

Therefore, the warning for unique indexes is a false positive, so I fixed.