### PR TITLE
Fix error in docker pull

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
       oracle:
-        image: deepdiver/docker-oracle-xe-11g
+        image: deepdiver/docker-oracle-xe-11g:2.0
         ports:
           - 1521
         env:


### PR DESCRIPTION
```
$ docker pull deepdiver/docker-oracle-xe-11g:latest
latest: Pulling from deepdiver/docker-oracle-xe-11g
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/deepdiver/docker-oracle-xe-11g:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

$ echo $?
1
```

https://github.com/sue445/index_shotgun/actions/runs/9521717398/job/26260278631