### PR TITLE
Fix `NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger` when activesupport < 7.1

### DIFF
--- a/lib/index_shotgun.rb
+++ b/lib/index_shotgun.rb
@@ -1,5 +1,9 @@
 require "index_shotgun/version"
 require "index_shotgun/analyzer"
+
+# FIXME: NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger when activesupport < 7.1
+require "logger"
+
 require "active_record"
 
 module IndexShotgun


### PR DESCRIPTION
Close #150